### PR TITLE
More rigorous checking of optional arguments

### DIFF
--- a/vkthread/vkthread.js
+++ b/vkthread/vkthread.js
@@ -59,7 +59,9 @@
 
   function _buildObj(obj, fn, args, context, importFiles){
 
-    if(Array.isArray(context)) {
+    if(typeof(importFiles) == "undefined" && Array.isArray(context) &&
+      context.length && typeof(context[0]) == "string")
+    {
       // the 4-th argument exist, but it is Array, which means 
       // that this is a list of imported files.
       obj.imprt = context;


### PR DESCRIPTION
I was looking to do array filtering in a webworker and noticed that context was not set correctly as it though it was a list of imports.

By the way, although retrospectively obvious, it might be worth noting somewhere clearly that native functions can't be serialized by JSONfn. :smile: 
(I used the polyfill from https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/filter)