### PR TITLE
Added status msg from the worker function (param.fn) to a callback function (param.fn).

### DIFF
--- a/vkthread/vkthread.js
+++ b/vkthread/vkthread.js
@@ -154,7 +154,10 @@
     );
   };
 
-  window.vkthread = new Vkthread();
-
+    // export as AMD module / Node module / browser or worker variable
+  if (typeof define === 'function' && define.amd) define(function () { return new Vkthread(); });
+  else if (typeof module !== 'undefined') module.exports = new Vkthread();
+  else if (typeof self !== 'undefined') self.vkthread = new Vkthread();
+  else window.vkthread = new Vkthread();
 }());
 

--- a/vkthread/vkthread.js
+++ b/vkthread/vkthread.js
@@ -92,7 +92,7 @@
 
         if (param.cb && typeof param.cb === 'function') {
           worker.onmessage = function (oEvent) {
-              if (typeof (oEvent.data.msg) !== "undefined") {
+              if (typeof (oEvent.data) !== "undefined" && typeof (oEvent.data.msg) !== "undefined") {
                   if (param.onmsg && typeof param.onmsg === 'function')
                       param.onmsg(oEvent.data.msg);
               } else {

--- a/vkthread/vkthread.js
+++ b/vkthread/vkthread.js
@@ -92,8 +92,13 @@
 
         if (param.cb && typeof param.cb === 'function') {
           worker.onmessage = function (oEvent) {
-            param.cb(oEvent.data);
-            worker.terminate();
+              if (typeof (oEvent.data.msg) !== "undefined") {
+                  if (param.onmsg && typeof param.onmsg === 'function')
+                      param.onmsg(oEvent.data.msg);
+              } else {
+                  param.cb(oEvent.data);
+                  worker.terminate();
+              }
           };
 
           worker.onerror = function(error) {


### PR DESCRIPTION
I added an ability to send status msg from the worker function (param.fn) to a callback function (param.onmsg). I also added support for AMD module / Node module / browser or worker variable.

 var param = {
     fn: // <-- function to run in a thread;
     args: // <-- function's arguments;
     cb: // <-- callback function for fn terminated; can be anonymous
     onmsg: // <-- callback function for "self.postMessage({ msg: <DATA> });" out of fn
  };